### PR TITLE
Add support to specify plugins to load

### DIFF
--- a/simple_plugin_loader/loader.py
+++ b/simple_plugin_loader/loader.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import pkgutil
 import sys
+from typing import List
 
 from simple_plugin_loader.sample_plugin import SamplePlugin
 
@@ -24,7 +25,7 @@ class _Loader():
 
     def load_plugins(self, path: str,
                      plugin_base_class: type=SamplePlugin,
-                     specific_plugins: list[str]=[],
+                     specific_plugins: List[str]=[],
                      recursive: bool=False,
                      verbose: bool=False) -> dict:
         """
@@ -65,7 +66,7 @@ class _Loader():
     def __load(self, path: str,
                package_name: str,
                plugin_base_class: type=SamplePlugin,
-               specific_plugins: list[str]=[],
+               specific_plugins: List[str]=[],
                recursive: bool=False,
                verbose: bool=False) -> dict:
         plugins = {}

--- a/simple_plugin_loader/loader.py
+++ b/simple_plugin_loader/loader.py
@@ -23,10 +23,10 @@ class _Loader():
         return self.__available_plugins
 
     def load_plugins(self, path: str,
-                     plugin_base_class: type = SamplePlugin,
-                     specific_plugins: list[str] = [],
-                     recursive: bool = False,
-                     verbose: bool = False) -> dict:
+                     plugin_base_class: type=SamplePlugin,
+                     specific_plugins: list[str]=[],
+                     recursive: bool=False,
+                     verbose: bool=False) -> dict:
         """
         Load all classes in a directory specified by 'path' that match the 'plugin_base_class' class.
         Alternatively if the 'specific_plugins' list contains class names, only those will be loaded.
@@ -64,10 +64,10 @@ class _Loader():
 
     def __load(self, path: str,
                package_name: str,
-               plugin_base_class: type = SamplePlugin,
-               specific_plugins: list[str] = [],
-               recursive: bool = False,
-               verbose: bool = False) -> dict:
+               plugin_base_class: type=SamplePlugin,
+               specific_plugins: list[str]=[],
+               recursive: bool=False,
+               verbose: bool=False) -> dict:
         plugins = {}
         # iterate over the modules that are within the path
         for (_, name, ispkg) in pkgutil.iter_modules([path]):

--- a/simple_plugin_loader/loader.py
+++ b/simple_plugin_loader/loader.py
@@ -23,11 +23,13 @@ class _Loader():
         return self.__available_plugins
 
     def load_plugins(self, path: str,
-                     plugin_base_class: type=SamplePlugin,
-                     recursive: bool=False,
-                     verbose: bool=False) -> dict:
+                     plugin_base_class: type = SamplePlugin,
+                     specific_plugins: list[str] = [],
+                     recursive: bool = False,
+                     verbose: bool = False) -> dict:
         """
         Load all classes in a directory specified by 'path' that match the 'plugin_base_class' class.
+        specific_plugins need to be the file name
 
         All other classes or methods are ignored.
         """
@@ -44,8 +46,10 @@ class _Loader():
 
         # do the actual import
         plugins = self.__load(path,
-                              os.path.basename(path),  # the module main package is the last directory of the path
+                              # the module main package is the last directory of the path
+                              os.path.basename(path),
                               plugin_base_class,
+                              specific_plugins,
                               recursive,
                               verbose)
 
@@ -59,9 +63,10 @@ class _Loader():
 
     def __load(self, path: str,
                package_name: str,
-               plugin_base_class: type=SamplePlugin,
-               recursive: bool=False,
-               verbose: bool=False) -> dict:
+               plugin_base_class: type = SamplePlugin,
+               specific_plugins: list[str] = [],
+               recursive: bool = False,
+               verbose: bool = False) -> dict:
         plugins = {}
         # iterate over the modules that are within the path
         for (_, name, ispkg) in pkgutil.iter_modules([path]):
@@ -70,12 +75,19 @@ class _Loader():
                     plugins.update(self.__load(os.path.join(path, name),
                                                ".".join([package_name, name]),
                                                plugin_base_class,
+                                               specific_plugins,
                                                recursive,
                                                verbose))
                     continue
                 else:
                     # do not try to import it, since it's not a module
                     continue
+
+            if len(specific_plugins) > 0 and name not in specific_plugins:
+                if verbose:
+                    print("Skipping plugin %s" %
+                          (".".join([package_name, name])))
+                continue
 
             # import the module
             try:

--- a/simple_plugin_loader/loader.py
+++ b/simple_plugin_loader/loader.py
@@ -102,13 +102,14 @@ class _Loader():
                 # first check if it's a class
                 if (inspect.isclass(attribute) and
                         # check if only specific plugins should be loaded
-                        (specific_plugins and
+                        ((specific_plugins and
                             # they must match the name case sensitive
                             attribute.__name__ in specific_plugins) or
-                        # otherwise check for plugin subclass
-                        (issubclass(attribute, plugin_base_class) and
-                         # but do not match the plugin class itself
-                         attribute != plugin_base_class)):
+                         # otherwise check for plugin subclass
+                         (not specific_plugins and
+                            issubclass(attribute, plugin_base_class) and
+                            # but do not match the plugin class itself
+                            attribute != plugin_base_class))):
                     # if the plugin is derived from 'SamplePlugin' class,
                     if issubclass(attribute, SamplePlugin):
                         # use the 'plugin_name' property as name

--- a/simple_plugin_loader/loader.py
+++ b/simple_plugin_loader/loader.py
@@ -48,8 +48,7 @@ class _Loader():
 
         # do the actual import
         plugins = self.__load(path,
-                              # the module main package is the last directory of the path
-                              os.path.basename(path),
+                              os.path.basename(path),  # the module main package is the last directory of the path
                               plugin_base_class,
                               specific_plugins,
                               recursive,

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
         self.assertIsInstance(plugin, TestPlugin)
 
     def load_non_recursive(self, verbose):
-        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin, recursive=False, verbose)
+        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin, recursive=False, verbose=verbose)
 
         self.check_plugin_loaded(plugins, "plugin1")
 
@@ -60,21 +60,21 @@ class Test(unittest.TestCase):
         sys.stderr = stderr
 
     def test_load_recursive(self):
-        plugins = self.loader.load_plugins(
-            PLUGIN_PATH, TestPlugin, recursive=True)
+        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin, recursive=True)
 
         self.check_plugin_loaded(plugins, "plugin1")
         self.check_plugin_loaded(plugins, "subplugin1")
         self.check_plugin_loaded(plugins, "subplugin2")
 
     def test_load_specific_plugins(self):
-        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin, [
-                                           'plugin1'], True, True)
+        # normally the class 'Plugin3NoSubclass' should not be loaded
+        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin)
+        self.assertNotIn("plugin3nosubclass", plugins)
 
-        self.check_plugin_loaded(plugins, "plugin1")
-        self.check_plugin_loaded(plugins, "subplugin2")
-
-        self.assertNotIn("subplugin1", plugins)
+        # now specify the class 'Plugin3NoSubclass' explicitly
+        plugins = self.loader.load_plugins(PLUGIN_PATH, specific_plugins=['Plugin3NoSubclass'])
+        self.assertIn("plugin3nosubclass", plugins)
+        self.assertNotIn("plugin1", plugins)
 
     def test_load_plugins_from_package_not_in_path(self):
         # this path is not in the current sys.path

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -25,7 +25,8 @@ class Test(unittest.TestCase):
         self.assertIsInstance(plugin, TestPlugin)
 
     def test_load_non_recursive(self):
-        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin, False)
+        plugins = self.loader.load_plugins(
+            PLUGIN_PATH, TestPlugin, recursive=False)
 
         self.check_plugin_loaded(plugins, "plugin1")
 
@@ -33,11 +34,21 @@ class Test(unittest.TestCase):
         self.assertNotIn("subplugin1", plugins)
 
     def test_load_recursive(self):
-        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin, True)
+        plugins = self.loader.load_plugins(
+            PLUGIN_PATH, TestPlugin, recursive=True)
 
         self.check_plugin_loaded(plugins, "plugin1")
         self.check_plugin_loaded(plugins, "subplugin1")
         self.check_plugin_loaded(plugins, "subplugin2")
+
+    def test_load_specific_plugins(self):
+        plugins = self.loader.load_plugins(PLUGIN_PATH, TestPlugin, [
+                                           'plugin1'], True, True)
+
+        self.check_plugin_loaded(plugins, "plugin1")
+        self.check_plugin_loaded(plugins, "subplugin2")
+
+        self.assertNotIn("subplugin1", plugins)
 
     def test_load_plugins_from_package_not_in_path(self):
         # this path is not in the current sys.path

--- a/tests/test_plugins/plugin3_no_subclass.py
+++ b/tests/test_plugins/plugin3_no_subclass.py
@@ -1,0 +1,2 @@
+class Plugin3NoSubclass():
+    pass


### PR DESCRIPTION
Hey, i add support to specify plugins to load, but i think is not the best approach bacause when the modules are found we have only the file name, so on this initial version we are checking only by file name.
I think we could check the class name but only after the module is load